### PR TITLE
Add spring-supported page request value handling for MVC endpoints

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -1,9 +1,13 @@
 com.google.code.findbugs:jsr305=3.0.1
 	
 com.google.guava:guava=23.0
+
+org.mockito:mockito-core=2.2.5
 	
 org.slf4j:slf4j-api=1.7.21
 org.slf4j:slf4j-simple=1.7.12
+
+org.springframework:spring-test=4.3.14.RELEASE
 	
 org.springframework.boot:spring-boot-starter-actuator=1.5.10.RELEASE
 org.springframework.boot:spring-boot-starter-web=1.5.10.RELEASE

--- a/main.app/build.gradle
+++ b/main.app/build.gradle
@@ -15,5 +15,7 @@ dependencies {
     compile group: 'org.springframework.security.oauth', name: 'spring-security-oauth2'
     compile group: 'org.springframework.cloud', name: 'spring-cloud-security'
     
+    testCompile group: 'org.mockito', name: 'mockito-core'
+    testCompile group: 'org.springframework', name: 'spring-test'
     testCompile group: 'org.testng', name: 'testng'
 }

--- a/main.app/src/main/java/org/starchartlabs/tempest/main/app/Tempest.java
+++ b/main.app/src/main/java/org/starchartlabs/tempest/main/app/Tempest.java
@@ -6,19 +6,29 @@
  */
 package org.starchartlabs.tempest.main.app;
 
+import java.util.List;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import org.starchartlabs.tempest.main.app.model.RequestPagingArgumentResolver;
 import org.starchartlabs.tempest.main.app.server.config.MainAppServerConfiguration;
 import org.starchartlabs.tempest.main.app.server.config.WebSecurityConfiguration;
 
 @SpringBootApplication
 @Import({ WebSecurityConfiguration.class,
     MainAppServerConfiguration.class })
-public class Tempest {
+public class Tempest extends WebMvcConfigurerAdapter {
 
     public static void main(String[] args) {
         SpringApplication.run(Tempest.class, args);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(new RequestPagingArgumentResolver());
     }
 
 }

--- a/main.app/src/main/java/org/starchartlabs/tempest/main/app/model/InvalidPagingArgumentException.java
+++ b/main.app/src/main/java/org/starchartlabs/tempest/main/app/model/InvalidPagingArgumentException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Mar 8, 2018 StarChart Labs Authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ */
+package org.starchartlabs.tempest.main.app.model;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Represents an out-of-bounds value for a paging parameter from a web request
+ *
+ * @author romeara
+ * @since 0.1.0
+ */
+@ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "Invalid value for paging operations provided")
+public class InvalidPagingArgumentException extends RuntimeException {
+
+    private static final long serialVersionUID = 6342347949663666619L;
+
+    /**
+     * @param message
+     *            Description of the specific issue with the paging parameters
+     * @since 0.1.0
+     */
+    public InvalidPagingArgumentException(String message) {
+        super(message);
+    }
+
+    /**
+     * Ensures the truth of an expression involving one or more parameters to the calling method
+     *
+     * @param expression
+     *            a boolean expression
+     * @param message
+     *            The message to use for the exception, should the expression be false
+     * @throws InvalidPagingArgumentException
+     *             If {@code expression} is false
+     * @since 0.1.0
+     */
+    public static void checkArgument(boolean expression, String message) {
+        if (!expression) {
+            throw new InvalidPagingArgumentException(message);
+        }
+    }
+
+}

--- a/main.app/src/main/java/org/starchartlabs/tempest/main/app/model/PageRequest.java
+++ b/main.app/src/main/java/org/starchartlabs/tempest/main/app/model/PageRequest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018 StarChart Labs Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.starchartlabs.tempest.main.app.model;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * Represents query parameters provided on a web resource that supports bounding of a variable number of available
+ * representations
+ *
+ * <p>
+ * Bounds results as "pages" - pre-defined sub-lists of ordered results. Clients control these pages by setting the
+ * number of results to include per page, the index of the page to retrieve, and the order in which results are provided
+ *
+ * <p>
+ * Supports:
+ *
+ * <ul>
+ * <li>perPage - The number of results to include in a single result. Minimum 1</li>
+ * <li>pageNumber - The index of the page to read. 0-indexed</li>
+ * <li>sort - Specification of the sort parameter(s) to use. Of form "(field) [asc/desc]". May be a CSV of multiple
+ * field and direction parameters</li>
+ * </ul>
+ *
+ * @author romeara
+ * @since 0.1.0
+ */
+public class PageRequest {
+
+    private final Integer pageNumber;
+
+    private final Integer perPage;
+
+    private final String sort;
+
+    /**
+     * @param pageNumber
+     *            The number of results to include in a single result. Minimum 1
+     * @param perPage
+     *            The index of the page to read. 0-indexed
+     * @param sort
+     *            Specification of the sort parameter(s) to use. Of form "(field) [asc/desc]". May be a CSV of multiple
+     *            field and direction parameters
+     * @since 0.1.0
+     */
+    public PageRequest(Integer pageNumber, Integer perPage, String sort) {
+        this.pageNumber = Objects.requireNonNull(pageNumber);
+        this.perPage = Objects.requireNonNull(perPage);
+        this.sort = Objects.requireNonNull(sort);
+
+        InvalidPagingArgumentException.checkArgument(this.pageNumber >= 0, "Cannot read a negative page");
+        InvalidPagingArgumentException.checkArgument(this.perPage >= 1, "Cannot read 0 or fewer values");
+        InvalidPagingArgumentException.checkArgument(!this.sort.trim().isEmpty(), "Cannot specify an empty sort");
+    }
+
+    /**
+     * @return The number of results to include in a single result. Minimum 1
+     * @since 0.1.0
+     */
+    public Integer getPageNumber() {
+        return pageNumber;
+    }
+
+    /**
+     * @return The index of the page to read. 0-indexed
+     * @since 0.1.0
+     */
+    public Integer getPerPage() {
+        return perPage;
+    }
+
+    /**
+     * @return Specification of the sort parameter(s) to use. Of form "(field) [asc/desc]". May be a CSV of multiple
+     *         field and direction parameters
+     * @since 0.1.0
+     */
+    public String getSort() {
+        return sort;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getPageNumber(),
+                getPerPage(),
+                getSort());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof PageRequest) {
+            PageRequest compare = (PageRequest) obj;
+
+            result = Objects.equals(compare.getPageNumber(), getPageNumber())
+                    && Objects.equals(compare.getPerPage(), getPerPage())
+                    && Objects.equals(compare.getSort(), getSort());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("pageNumber", getPageNumber())
+                .add("perPage", getPerPage())
+                .add("sort", getSort())
+                .toString();
+    }
+
+}

--- a/main.app/src/main/java/org/starchartlabs/tempest/main/app/model/RequestPaging.java
+++ b/main.app/src/main/java/org/starchartlabs/tempest/main/app/model/RequestPaging.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Mar 7, 2018 StarChart Labs Authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ */
+package org.starchartlabs.tempest.main.app.model;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation which indicates that a method parameter should be bound to a multiple web request parameters specifying
+ * paging behavior on a response with variable length
+ *
+ * <p>
+ * Used to specify a paging parameter representation, and defaults for values not explictly specified in a request
+ *
+ * <p>
+ * Clients should configure Spring MVC with {@link RequestPagingArgumentResolver} to add support for use of this
+ * annotation
+ *
+ * @author romeara
+ * @since 0.1.0
+ */
+@Documented
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequestPaging {
+
+    /**
+     * @return Query parameter to read the page index to read from on requests. Defaults to "page"
+     * @since 0.1.0
+     */
+    String pageName() default "page";
+
+    /**
+     * @return Query parameter to read the maximum number of elements to include in a single response from on requests.
+     *         Defaults to "per_page"
+     * @since 0.1.0
+     */
+    String perPageName() default "per_page";
+
+    /**
+     * @return Query parameter to read sort specifications from on requests. Defaults to "sort"
+     * @since 0.1.0
+     */
+    String sortName() default "sort";
+
+    /**
+     * @return The default page index to read if no explicit value is provided with a request (0-indexed). Defaults to
+     *         "0"
+     * @since 0.1.0
+     */
+    String defaultPage() default "0";
+
+    /**
+     * @return The default maximum number of elements to include in a single response if no explicit value is provided
+     *         with a request. Defaults to "10"
+     * @since 0.1.0
+     */
+    String defaultPerPage() default "10";
+
+    /**
+     * @return The default representation of a sort specification to assign to requests without an explicit sort
+     *         defined. Required, as a reasonable default will vary based on sort specifications and the representations
+     *         being sorted
+     * @since 0.1.0
+     */
+    String defaultSort();
+
+}

--- a/main.app/src/main/java/org/starchartlabs/tempest/main/app/model/RequestPagingArgumentResolver.java
+++ b/main.app/src/main/java/org/starchartlabs/tempest/main/app/model/RequestPagingArgumentResolver.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Mar 7, 2018 StarChart Labs Authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ */
+package org.starchartlabs.tempest.main.app.model;
+
+import java.util.Optional;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * Implementation of {@link HandlerMethodArgumentResolver} which handles spring MVC {@link PageRequest} input parameters
+ * annotated with {@ RequestPaging}
+ *
+ * <p>
+ * Utilizes annotation values to determine the query parameters to read paging values from, and to determine default
+ * values if none are specified on the request
+ *
+ * <p>
+ * Intended to be configured on a Spring Web MVC Configurer to use on MVC endpoints. In Spring 5.0 and later, done via:
+ *
+ * <pre>
+ * public class Example implements WebMvcConfigurer {
+ *
+ *     &#64;Override
+ *     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+ *         argumentResolvers.add(new RequestPagingArgumentResolver());
+ *     }
+ *
+ * }
+ * </pre>
+ *
+ * <p>
+ * In Spring 4.x and earlier, done via:
+ *
+ * <pre>
+ * public class Example extends WebMvcConfigurerAdapter {
+ *
+ *     &#64;Override
+ *     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+ *         argumentResolvers.add(new RequestPagingArgumentResolver());
+ *     }
+ *
+ * }
+ * </pre>
+ *
+ * @author romeara
+ * @since 0.1.0
+ */
+public class RequestPagingArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(PageRequest.class)
+                && parameter.getParameterAnnotation(RequestPaging.class) != null;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        String pageParameter = parameter.getParameterAnnotation(RequestPaging.class).pageName();
+        String perPageParameter = parameter.getParameterAnnotation(RequestPaging.class).perPageName();
+        String sortParameter = parameter.getParameterAnnotation(RequestPaging.class).sortName();
+
+        String defaultPage = parameter.getParameterAnnotation(RequestPaging.class).defaultPage();
+        String defaultPerPage = parameter.getParameterAnnotation(RequestPaging.class).defaultPerPage();
+        String defaultSort = parameter.getParameterAnnotation(RequestPaging.class).defaultSort();
+
+        Integer page = getInteger(pageParameter, defaultPage, webRequest, parameter);
+        Integer perPage = getInteger(perPageParameter, defaultPerPage, webRequest, parameter);
+        String sort = Optional.ofNullable(webRequest.getParameter(sortParameter))
+                .orElse(defaultSort);
+
+        return new PageRequest(page, perPage, sort);
+    }
+
+    /**
+     * Reads and converts a query parameter expected to be an integer from the current request
+     *
+     * <p>
+     * Throws an exception if the effective value is not a number
+     *
+     * @param parameterName
+     *            The name of the query parameter to read the request
+     * @param defaultValue
+     *            The default value to use if the current request does not have a value specified
+     * @param webRequest
+     *            The current web request
+     * @param parameter
+     *            The method parameter the read value will contribute to
+     * @return Integer representation of the value the application should consume
+     */
+    private Integer getInteger(String parameterName, String defaultValue, NativeWebRequest webRequest,
+            MethodParameter parameter) {
+        String value = Optional.ofNullable(webRequest.getParameter(parameterName))
+                .orElse(defaultValue);
+
+        try {
+            return Integer.valueOf(value);
+        } catch (NumberFormatException e) {
+            throw new MethodArgumentTypeMismatchException(value, Integer.class, parameterName, parameter, e);
+        }
+    }
+
+}

--- a/main.app/src/main/java/org/starchartlabs/tempest/main/app/model/RequestPagingArgumentResolver.java
+++ b/main.app/src/main/java/org/starchartlabs/tempest/main/app/model/RequestPagingArgumentResolver.java
@@ -69,18 +69,13 @@ public class RequestPagingArgumentResolver implements HandlerMethodArgumentResol
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
             NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
-        String pageParameter = parameter.getParameterAnnotation(RequestPaging.class).pageName();
-        String perPageParameter = parameter.getParameterAnnotation(RequestPaging.class).perPageName();
-        String sortParameter = parameter.getParameterAnnotation(RequestPaging.class).sortName();
+        RequestPaging requestPaging = parameter.getParameterAnnotation(RequestPaging.class);
 
-        String defaultPage = parameter.getParameterAnnotation(RequestPaging.class).defaultPage();
-        String defaultPerPage = parameter.getParameterAnnotation(RequestPaging.class).defaultPerPage();
-        String defaultSort = parameter.getParameterAnnotation(RequestPaging.class).defaultSort();
-
-        Integer page = getInteger(pageParameter, defaultPage, webRequest, parameter);
-        Integer perPage = getInteger(perPageParameter, defaultPerPage, webRequest, parameter);
-        String sort = Optional.ofNullable(webRequest.getParameter(sortParameter))
-                .orElse(defaultSort);
+        Integer page = getInteger(requestPaging.pageName(), requestPaging.defaultPage(), webRequest, parameter);
+        Integer perPage = getInteger(requestPaging.perPageName(), requestPaging.defaultPerPage(), webRequest,
+                parameter);
+        String sort = Optional.ofNullable(webRequest.getParameter(requestPaging.sortName()))
+                .orElse(requestPaging.defaultSort());
 
         return new PageRequest(page, perPage, sort);
     }

--- a/main.app/src/main/java/org/starchartlabs/tempest/main/app/model/RequestPagingArgumentResolver.java
+++ b/main.app/src/main/java/org/starchartlabs/tempest/main/app/model/RequestPagingArgumentResolver.java
@@ -21,7 +21,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 /**
  * Implementation of {@link HandlerMethodArgumentResolver} which handles spring MVC {@link PageRequest} input parameters
- * annotated with {@ RequestPaging}
+ * annotated with {@link RequestPaging}
  *
  * <p>
  * Utilizes annotation values to determine the query parameters to read paging values from, and to determine default
@@ -34,7 +34,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  * public class Example implements WebMvcConfigurer {
  *
  *     &#64;Override
- *     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+ *     public void addArgumentResolvers(List&lt;HandlerMethodArgumentResolver&gt; argumentResolvers) {
  *         argumentResolvers.add(new RequestPagingArgumentResolver());
  *     }
  *
@@ -48,7 +48,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  * public class Example extends WebMvcConfigurerAdapter {
  *
  *     &#64;Override
- *     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+ *     public void addArgumentResolvers(List&lt;HandlerMethodArgumentResolver&gt; argumentResolvers) {
  *         argumentResolvers.add(new RequestPagingArgumentResolver());
  *     }
  *

--- a/main.app/src/main/java/org/starchartlabs/tempest/main/app/model/package-info.java
+++ b/main.app/src/main/java/org/starchartlabs/tempest/main/app/model/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 StarChart Labs Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Core definition of data structures used for external representations of application data
+ *
+ * @author romeara
+ * @since 0.1.0
+ */
+@ParametersAreNonnullByDefault
+package org.starchartlabs.tempest.main.app.model;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/main.app/src/test/java/org/starchartlabs/tempest/test/main/app/model/PageRequestTest.java
+++ b/main.app/src/test/java/org/starchartlabs/tempest/test/main/app/model/PageRequestTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Mar 8, 2018 StarChart Labs Authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ */
+package org.starchartlabs.tempest.test.main.app.model;
+
+import org.starchartlabs.tempest.main.app.model.InvalidPagingArgumentException;
+import org.starchartlabs.tempest.main.app.model.PageRequest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PageRequestTest {
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullPageNumber() throws Exception {
+        new PageRequest(null, 10, "sort asc");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullPage() throws Exception {
+        new PageRequest(0, null, "sort asc");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullSort() throws Exception {
+        new PageRequest(0, 10, null);
+    }
+
+    @Test(expectedExceptions = InvalidPagingArgumentException.class)
+    public void constructInvalidPageNumber() throws Exception {
+        new PageRequest(-1, 10, "sort asc");
+    }
+
+    @Test(expectedExceptions = InvalidPagingArgumentException.class)
+    public void constructInvalidPerPage() throws Exception {
+        new PageRequest(0, 0, "sort asc");
+    }
+
+    @Test(expectedExceptions = InvalidPagingArgumentException.class)
+    public void constructEmptySort() throws Exception {
+        new PageRequest(0, 10, " ");
+    }
+
+    @Test
+    public void getTest() throws Exception {
+        PageRequest result = new PageRequest(0, 10, "sort asc");
+
+        Assert.assertEquals(result.getPageNumber().intValue(), 0);
+        Assert.assertEquals(result.getPerPage().intValue(), 10);
+        Assert.assertEquals(result.getSort(), "sort asc");
+    }
+
+    @Test
+    public void hashCodeEqualWhenDataEqual() throws Exception {
+        PageRequest result1 = new PageRequest(0, 10, "sort asc");
+        PageRequest result2 = new PageRequest(0, 10, "sort asc");
+
+        Assert.assertEquals(result1.hashCode(), result2.hashCode());
+    }
+
+    @Test
+    public void equalsNull() throws Exception {
+        PageRequest result = new PageRequest(0, 10, "sort asc");
+
+        Assert.assertFalse(result.equals(null));
+    }
+
+    @Test
+    public void equalsDifferentClass() throws Exception {
+        PageRequest result = new PageRequest(0, 10, "sort asc");
+
+        Assert.assertFalse(result.equals("string"));
+    }
+
+    @Test
+    public void equalsSelf() throws Exception {
+        PageRequest result = new PageRequest(0, 10, "sort asc");
+
+        Assert.assertTrue(result.equals(result));
+    }
+
+    @Test
+    public void equalsDifferentData() throws Exception {
+        PageRequest result1 = new PageRequest(0, 10, "sort asc");
+        PageRequest result2 = new PageRequest(1, 10, "sort asc");
+
+        Assert.assertFalse(result1.equals(result2));
+    }
+
+    @Test
+    public void equalsSameData() throws Exception {
+        PageRequest result1 = new PageRequest(0, 10, "sort asc");
+        PageRequest result2 = new PageRequest(0, 10, "sort asc");
+
+        Assert.assertTrue(result1.equals(result2));
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        PageRequest obj = new PageRequest(0, 10, "sort asc");
+
+        String result = obj.toString();
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.contains("pageNumber=0"));
+        Assert.assertTrue(result.contains("perPage=10"));
+        Assert.assertTrue(result.contains("sort=sort asc"));
+    }
+
+}

--- a/main.app/src/test/java/org/starchartlabs/tempest/test/main/app/model/RequestPagingArgumentResolverTest.java
+++ b/main.app/src/test/java/org/starchartlabs/tempest/test/main/app/model/RequestPagingArgumentResolverTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) Mar 8, 2018 StarChart Labs Authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ */
+package org.starchartlabs.tempest.test.main.app.model;
+
+import java.util.Objects;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.starchartlabs.tempest.main.app.model.PageRequest;
+import org.starchartlabs.tempest.main.app.model.RequestPaging;
+import org.starchartlabs.tempest.main.app.model.RequestPagingArgumentResolver;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class RequestPagingArgumentResolverTest {
+
+    private static final String DEFAULTS = "/defaults";
+
+    private static final String NO_DEFAULTS = "/no-defaults";
+
+    private static final String DEFAULT_SORT = "test asc";
+
+    /** Logger reference to output information to the application log files */
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Mock
+    private ReceivedParameterCapture receivedParameterCapture;
+
+    private MockMvc mockMvc;
+
+    @BeforeMethod
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(new TestServer(receivedParameterCapture))
+                .setCustomArgumentResolvers(new RequestPagingArgumentResolver())
+                .build();
+    }
+
+    @AfterMethod(alwaysRun = false)
+    public void verifyNoMoreInteractions(ITestResult result) {
+        logger.trace("Verifying interactions for {}", result.getMethod().getMethodName());
+
+        Mockito.verifyNoMoreInteractions(receivedParameterCapture);
+    }
+
+    @Test
+    public void defaultsNoQueryParameters() throws Exception {
+        PageRequest expected = new PageRequest(0, 10, DEFAULT_SORT);
+        String url = DEFAULTS;
+
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(url));
+
+        result.andDo(MockMvcResultHandlers.print())
+        .andExpect(MockMvcResultMatchers.status().isOk());
+
+        Mockito.verify(receivedParameterCapture).capturePageRequest(expected);
+    }
+
+    @Test
+    public void defaultsAllQueryParameters() throws Exception {
+        PageRequest expected = new PageRequest(10, 100, "override desc");
+        String url = DEFAULTS;
+
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(url)
+                .param("page", expected.getPageNumber().toString())
+                .param("per_page", expected.getPerPage().toString())
+                .param("sort", expected.getSort()));
+
+        result.andDo(MockMvcResultHandlers.print())
+        .andExpect(MockMvcResultMatchers.status().isOk());
+
+        Mockito.verify(receivedParameterCapture).capturePageRequest(expected);
+    }
+
+    @Test
+    public void defaultsMalformedPerPage() throws Exception {
+        String url = DEFAULTS;
+
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(url)
+                .param("per_page", "nan"));
+
+        result.andDo(MockMvcResultHandlers.print())
+        .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    @Test
+    public void defaultsInvalidPerPage() throws Exception {
+        String url = DEFAULTS;
+
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(url)
+                .param("per_page", "0"));
+
+        result.andDo(MockMvcResultHandlers.print())
+        .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    @Test
+    public void defaultsMalformedPage() throws Exception {
+        String url = DEFAULTS;
+
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(url)
+                .param("page", "nan"));
+
+        result.andDo(MockMvcResultHandlers.print())
+        .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    @Test
+    public void defaultsInvalidPage() throws Exception {
+        String url = DEFAULTS;
+
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(url)
+                .param("page", "-1"));
+
+        result.andDo(MockMvcResultHandlers.print())
+        .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    @Test
+    public void defaultsInvalidSort() throws Exception {
+        String url = DEFAULTS;
+
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(url)
+                .param("sort", " "));
+
+        result.andDo(MockMvcResultHandlers.print())
+        .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    @Test
+    public void noDefaultsNoQueryParameters() throws Exception {
+        PageRequest expected = new PageRequest(1, 20, "sort desc");
+        String url = NO_DEFAULTS;
+
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(url));
+
+        result.andDo(MockMvcResultHandlers.print())
+        .andExpect(MockMvcResultMatchers.status().isOk());
+
+        Mockito.verify(receivedParameterCapture).capturePageRequest(expected);
+    }
+
+    @Test
+    public void noDefaultsAllQueryParameters() throws Exception {
+        PageRequest expected = new PageRequest(30, 300, "something desc");
+        String url = NO_DEFAULTS;
+
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(url)
+                .param("p", expected.getPageNumber().toString())
+                .param("pp", expected.getPerPage().toString())
+                .param("s", expected.getSort()));
+
+        result.andDo(MockMvcResultHandlers.print())
+        .andExpect(MockMvcResultMatchers.status().isOk());
+
+        Mockito.verify(receivedParameterCapture).capturePageRequest(expected);
+    }
+
+    @Test
+    public void noDefaultsMalformedPerPage() throws Exception {
+        String url = NO_DEFAULTS;
+
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(url)
+                .param("pp", "nan"));
+
+        result.andDo(MockMvcResultHandlers.print())
+        .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    @Test
+    public void noDefaultsInvalidPerPage() throws Exception {
+        String url = NO_DEFAULTS;
+
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(url)
+                .param("pp", "0"));
+
+        result.andDo(MockMvcResultHandlers.print())
+        .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    @Test
+    public void noDefaultsMalformedPage() throws Exception {
+        String url = NO_DEFAULTS;
+
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(url)
+                .param("p", "nan"));
+
+        result.andDo(MockMvcResultHandlers.print())
+        .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    @Test
+    public void noDefaultsInvalidPage() throws Exception {
+        String url = NO_DEFAULTS;
+
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(url)
+                .param("p", "-1"));
+
+        result.andDo(MockMvcResultHandlers.print())
+        .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    @Test
+    public void noDefaultsInvalidSort() throws Exception {
+        String url = NO_DEFAULTS;
+
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(url)
+                .param("s", " "));
+
+        result.andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    @RestController
+    public static class TestServer {
+
+        private final ReceivedParameterCapture receivedParameterCapture;
+
+        public TestServer(ReceivedParameterCapture receivedParameterCapture) {
+            this.receivedParameterCapture = Objects.requireNonNull(receivedParameterCapture);
+        }
+
+        @RequestMapping(method = { RequestMethod.GET }, path = DEFAULTS)
+        public ResponseEntity<Void> getPagedResourceDefaults(
+                @RequestPaging(defaultSort = DEFAULT_SORT) PageRequest pageRequest) {
+            receivedParameterCapture.capturePageRequest(pageRequest);
+
+            return new ResponseEntity<>(HttpStatus.OK);
+        }
+
+        @RequestMapping(method = { RequestMethod.GET }, path = NO_DEFAULTS)
+        public ResponseEntity<Void> getPagedResourceNoDefaults(
+                @RequestPaging(pageName = "p", perPageName = "pp", sortName = "s",
+                defaultPage = "1", defaultPerPage = "20", defaultSort = "sort desc") PageRequest pageRequest) {
+            receivedParameterCapture.capturePageRequest(pageRequest);
+
+            return new ResponseEntity<>(HttpStatus.OK);
+        }
+
+    }
+
+    public static interface ReceivedParameterCapture {
+
+        void capturePageRequest(PageRequest pageRequest);
+
+    }
+}


### PR DESCRIPTION
Adds a page request representation, and an annotation which integrates with Spring MVC for more up-front error handling/validation before requests enter the back-end

The first of a few things that we will likely want to break out into a library once the APIs have been proven out in some real-world use in Tempest APIs

Example use of annotation:

```
@RequestMapping(method = { RequestMethod.GET }, path = "/example")
public ResponseEntity<Void> getExample(@RequestPaging(defaultSort = "field asc") PageRequest pageRequest) {
    return new ResponseEntity<>(HttpStatus.OK);
}
```

Example setup of Spring integration:

```
public class Example extends WebMvcConfigurerAdapter {

    @Override
    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
        argumentResolvers.add(new RequestPagingArgumentResolver());
    }

}
```