### PR TITLE
Add position representation for paged responses

### DIFF
--- a/core.rest/src/main/java/org/starchartlabs/tempest/core/rest/model/PageRequest.java
+++ b/core.rest/src/main/java/org/starchartlabs/tempest/core/rest/model/PageRequest.java
@@ -19,7 +19,10 @@ import java.util.Objects;
 
 import javax.annotation.Nullable;
 
+import org.springframework.web.util.UriComponentsBuilder;
+
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 
 /**
  * Represents query parameters provided on a web resource that supports bounding of a variable number of available
@@ -93,6 +96,53 @@ public class PageRequest {
      */
     public String getSort() {
         return sort;
+    }
+
+    /**
+     * Generates a page request using the same sorting and per-page parameters as this request for a specified page
+     * number
+     *
+     * @param pageNumber
+     *            The index of the page to generate a request representation for (0 - indexed)
+     * @return A page request using the same sorting and per-page parameters as this request, for the specified page
+     *         number
+     * @since 0.1.0
+     */
+    public PageRequest getForPageNumber(int pageNumber) {
+        Preconditions.checkArgument(pageNumber >= 0, "Cannot request a negative page");
+
+        return new PageRequest(pageNumber, getPerPage(), getSort());
+    }
+
+    /**
+     * Adds the page request parameters to a string URI representation as query parameters
+     *
+     * @param baseUrl
+     *            Base URI to construct a web address from
+     * @return The URI builder initialized with provided URI string and paging parameters
+     * @since 0.1.0
+     */
+    public UriComponentsBuilder applyUrlQuery(String baseUrl) {
+        Objects.requireNonNull(baseUrl);
+
+        return applyUrlQuery(UriComponentsBuilder.fromUriString(baseUrl));
+    }
+
+    /**
+     * Adds the page request parameters to a URI builder as query parameters
+     *
+     * @param builder
+     *            URI builder being used to construct a web address
+     * @return The provided URI builder with paging parameters
+     * @since 0.1.0
+     */
+    public UriComponentsBuilder applyUrlQuery(UriComponentsBuilder builder) {
+        Objects.requireNonNull(builder);
+
+        return builder
+                .queryParam("page", getPageNumber())
+                .queryParam("per_page", getPerPage())
+                .queryParam("sort", getSort());
     }
 
     @Override

--- a/core.rest/src/main/java/org/starchartlabs/tempest/core/rest/model/PositionView.java
+++ b/core.rest/src/main/java/org/starchartlabs/tempest/core/rest/model/PositionView.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2018 StarChart Labs Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.starchartlabs.tempest.core.rest.model;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+
+/**
+ * Represents page navigation links and position data based on the current location in a paginated data series
+ *
+ * <p>
+ * Provided as part of paginated responses for ease-of-use by clients presenting current and available data to end-users
+ *
+ * <p>
+ * Intended for serialization to JSON in the form:
+ *
+ * <pre>
+ * {
+ *      "index": "0",
+ *      "lastIndex": "0",
+ *      "firstPage": "http://...",
+ *      "previousPage": "http://...",
+ *      "nextPage": "http://...",
+ *      "lastPage": "http://...",
+ * }
+ * </pre>
+ *
+ * @author romeara
+ * @since 0.1.0
+ */
+@JsonInclude(Include.NON_NULL)
+public class PositionView {
+
+    @JsonProperty(value = "index", required = true)
+    private final Integer index;
+
+    @JsonProperty(value = "lastIndex", required = true)
+    private final Integer lastIndex;
+
+    @JsonProperty(value = "totalElements", required = true)
+    private final Integer totalElements;
+
+    @JsonProperty(value = "firstPage", required = false)
+    private final String firstPage;
+
+    @JsonProperty(value = "previousPage", required = false)
+    private final String previousPage;
+
+    @JsonProperty(value = "nextPage", required = false)
+    private final String nextPage;
+
+    @JsonProperty(value = "lastPage", required = false)
+    private final String lastPage;
+
+    /**
+     * Creates a representation of page navigation links and position data based on the current page state
+     *
+     * @param request
+     *            The page request which details the page index and number of elements per page
+     * @param elementsInPage
+     *            The number of elements provided in the current page
+     * @param totalElements
+     *            The total number of elements available to be paged
+     * @param baseUrl
+     *            The URL to the resource being paged, without any of the paging parameters set
+     * @since 0.1.0
+     */
+    public PositionView(PageRequest request, int elementsInPage, int totalElements, String baseUrl) {
+        Objects.requireNonNull(request);
+        Objects.requireNonNull(baseUrl);
+
+        Preconditions.checkArgument(elementsInPage >= 0,
+                "There cannot be less that 0 elements in the page (Input: " + elementsInPage + ")");
+        Preconditions.checkArgument(totalElements >= 0,
+                "There cannot be less that 0 total elements (Input: " + totalElements + ")");
+        Preconditions.checkArgument(elementsInPage <= totalElements,
+                "There cannot be more elements in the page than total elements (Input: " + elementsInPage + ", "
+                        + totalElements + ")");
+
+        int elementsInPreviousPages = request.getPageNumber() * request.getPerPage();
+        int maxPage = Math.max((totalElements / request.getPerPage()) - 1, 0);
+
+        if (totalElements > 0 && (totalElements > request.getPerPage())
+                && (totalElements % request.getPerPage()) != 0) {
+            maxPage++;
+        }
+
+        // If not the first page, provide first and previous links
+        if (request.getPageNumber() > 0) {
+            firstPage = getPageUrl(request, 0, baseUrl);
+            previousPage = getPageUrl(request, request.getPageNumber() - 1, baseUrl);
+        } else {
+            firstPage = null;
+            previousPage = null;
+        }
+
+        // If not the last page, provide next and last links
+        if (elementsInPreviousPages + elementsInPage < totalElements) {
+            lastPage = getPageUrl(request, maxPage, baseUrl);
+            nextPage = getPageUrl(request, request.getPageNumber() + 1, baseUrl);
+        } else {
+            lastPage = null;
+            nextPage = null;
+        }
+
+        index = request.getPageNumber();
+        lastIndex = maxPage;
+        this.totalElements = totalElements;
+    }
+
+    /**
+     * @return Index of the represented page. 0 indexed
+     * @since 0.1.0
+     */
+    public Integer getIndex() {
+        return index;
+    }
+
+    /**
+     * @return Index of the last page in the data series being paginated. 0 indexed
+     * @since 0.1.0
+     */
+    public Integer getLastIndex() {
+        return lastIndex;
+    }
+
+    /**
+     * @return The total number of elements available to be paged
+     * @since 0.1.0
+     */
+    public Integer getTotalElements() {
+        return totalElements;
+    }
+
+    /**
+     * @see Include#NON_NULL
+     * @return Link to the first page in the data series being paginated. Null if the current position is the first page
+     * @since 0.1.0
+     */
+    @Nullable
+    public String getFirstPage() {
+        return firstPage;
+    }
+
+    /**
+     * @see Include#NON_NULL
+     * @return Link to the previous page in the data series being paginated. Null if the current position is the first
+     *         page
+     * @since 0.1.0
+     */
+    @Nullable
+    public String getPreviousPage() {
+        return previousPage;
+    }
+
+    /**
+     * @see Include#NON_NULL
+     * @return Link to the next page in the data series being paginated. Null if the current position is the last page
+     * @since 0.1.0
+     */
+    @Nullable
+    public String getNextPage() {
+        return nextPage;
+    }
+
+    /**
+     * @see Include#NON_NULL
+     * @return Link to the last page in the data series being paginated. Null if the current position is the last page
+     * @since 0.1.0
+     */
+    @Nullable
+    public String getLastPage() {
+        return lastPage;
+    }
+
+    /**
+     * Generates the URL to access an arbitrary page with a given number of maximum elements
+     *
+     * @param currentPage
+     *            Page request detailing the current associated page's parameters
+     * @param pageNumber
+     *            The number of the page the URL will access (0-indexed)
+     * @param baseUrl
+     *            The URL to the resource being paged, without any of the paging parameters set
+     * @return A URL which stably accesses the provided resource in a paged manner
+     */
+    private String getPageUrl(PageRequest currentPage, int pageNumber, String baseUrl) {
+        Objects.requireNonNull(currentPage);
+        Objects.requireNonNull(baseUrl);
+
+        PageRequest targetPageRequst = currentPage.getForPageNumber(pageNumber);
+
+        return targetPageRequst.applyUrlQuery(baseUrl)
+                .build()
+                .toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getIndex(),
+                getLastIndex(),
+                getTotalElements(),
+                getFirstPage(),
+                getPreviousPage(),
+                getNextPage(),
+                getLastPage());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof PositionView) {
+            PositionView compare = (PositionView) obj;
+
+            result = Objects.equals(compare.getIndex(), getIndex())
+                    && Objects.equals(compare.getLastIndex(), getLastIndex())
+                    && Objects.equals(compare.getTotalElements(), getTotalElements())
+                    && Objects.equals(compare.getFirstPage(), getFirstPage())
+                    && Objects.equals(compare.getPreviousPage(), getPreviousPage())
+                    && Objects.equals(compare.getNextPage(), getNextPage())
+                    && Objects.equals(compare.getLastPage(), getLastPage());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("index", getIndex())
+                .add("lastIndex", getLastIndex())
+                .add("totalElements", getTotalElements())
+                .add("firstPage", getFirstPage())
+                .add("previousPage", getPreviousPage())
+                .add("nextPage", getNextPage())
+                .add("lastPage", getLastPage())
+                .toString();
+    }
+
+}

--- a/core.rest/src/test/java/org/starchartlabs/tempest/test/core/rest/model/PageRequestTest.java
+++ b/core.rest/src/test/java/org/starchartlabs/tempest/test/core/rest/model/PageRequestTest.java
@@ -10,6 +10,9 @@
  */
 package org.starchartlabs.tempest.test.core.rest.model;
 
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 import org.starchartlabs.tempest.core.rest.model.InvalidPagingArgumentException;
 import org.starchartlabs.tempest.core.rest.model.PageRequest;
 import org.testng.Assert;
@@ -45,6 +48,74 @@ public class PageRequestTest {
     @Test(expectedExceptions = InvalidPagingArgumentException.class)
     public void constructEmptySort() throws Exception {
         new PageRequest(0, 10, " ");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void getForPageNumberNegativePage() throws Exception {
+        PageRequest request = new PageRequest(0, 10, "sort asc");
+
+        request.getForPageNumber(-1);
+    }
+
+    @Test
+    public void getForPageNumber() throws Exception {
+        PageRequest request = new PageRequest(0, 10, "sort asc");
+
+        PageRequest result = request.getForPageNumber(100);
+
+        Assert.assertEquals(result.getPageNumber().intValue(), 100);
+        Assert.assertEquals(result.getPerPage().intValue(), 10);
+        Assert.assertEquals(result.getSort(), "sort asc");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void applyUrlQueryNullStringUrl() throws Exception {
+        PageRequest request = new PageRequest(0, 10, "sort asc");
+
+        request.applyUrlQuery((String) null);
+    }
+
+    @Test
+    public void applyUrlQueryStringUrl() throws Exception {
+        PageRequest request = new PageRequest(0, 10, "sort asc");
+
+        UriComponents result = request.applyUrlQuery("http://localhost").build();
+
+        MultiValueMap<String, String> parameters = result.getQueryParams();
+
+        Assert.assertEquals(parameters.size(), 3);
+        Assert.assertEquals(parameters.get("page").size(), 1);
+        Assert.assertEquals(parameters.get("per_page").size(), 1);
+        Assert.assertEquals(parameters.get("sort").size(), 1);
+
+        Assert.assertEquals(parameters.getFirst("page"), "0");
+        Assert.assertEquals(parameters.getFirst("per_page"), "10");
+        Assert.assertEquals(parameters.getFirst("sort"), "sort asc");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void applyUrlQueryNullBuilder() throws Exception {
+        PageRequest request = new PageRequest(0, 10, "sort asc");
+
+        request.applyUrlQuery((UriComponentsBuilder) null);
+    }
+
+    @Test
+    public void applyUrlQueryBuilder() throws Exception {
+        PageRequest request = new PageRequest(0, 10, "sort asc");
+
+        UriComponents result = request.applyUrlQuery(UriComponentsBuilder.fromUriString("http://localhost")).build();
+
+        MultiValueMap<String, String> parameters = result.getQueryParams();
+
+        Assert.assertEquals(parameters.size(), 3);
+        Assert.assertEquals(parameters.get("page").size(), 1);
+        Assert.assertEquals(parameters.get("per_page").size(), 1);
+        Assert.assertEquals(parameters.get("sort").size(), 1);
+
+        Assert.assertEquals(parameters.getFirst("page"), "0");
+        Assert.assertEquals(parameters.getFirst("per_page"), "10");
+        Assert.assertEquals(parameters.getFirst("sort"), "sort asc");
     }
 
     @Test

--- a/core.rest/src/test/java/org/starchartlabs/tempest/test/core/rest/model/PositionViewTest.java
+++ b/core.rest/src/test/java/org/starchartlabs/tempest/test/core/rest/model/PositionViewTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) Apr 2, 2018 StarChart Labs Authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ */
+package org.starchartlabs.tempest.test.core.rest.model;
+
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.starchartlabs.tempest.core.rest.model.PageRequest;
+import org.starchartlabs.tempest.core.rest.model.PositionView;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PositionViewTest {
+
+    private static final PageRequest PAGE_REQUEST = new PageRequest(1, 10, "sort asc");
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullPageRequest() throws Exception {
+        new PositionView(null, 1, 1, "http://localhost");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullBaseUrl() throws Exception {
+        new PositionView(PAGE_REQUEST, 1, 1, null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void constructNegativeElementsInPage() throws Exception {
+        new PositionView(PAGE_REQUEST, -1, 1, "http://localhost");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void constructNegativeTotalElements() throws Exception {
+        new PositionView(PAGE_REQUEST, 1, -1, "http://localhost");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void constructMoreElementsInPageThanTotalElements() throws Exception {
+        new PositionView(PAGE_REQUEST, 2, 1, "http://localhost");
+    }
+
+    @Test
+    public void singlePage() throws Exception {
+        PageRequest pageRequest = new PageRequest(0, 10, "sort asc");
+
+        PositionView result = new PositionView(pageRequest, 10, 10, "http://localhost");
+
+        Assert.assertEquals(result.getIndex().intValue(), 0);
+        Assert.assertEquals(result.getLastIndex().intValue(), 0);
+        Assert.assertEquals(result.getTotalElements().intValue(), 10);
+
+        Assert.assertNull(result.getFirstPage());
+        Assert.assertNull(result.getPreviousPage());
+        Assert.assertNull(result.getNextPage());
+        Assert.assertNull(result.getLastPage());
+    }
+
+    @Test
+    public void firstPage() throws Exception {
+        PageRequest pageRequest = new PageRequest(0, 10, "sort asc");
+
+        PositionView result = new PositionView(pageRequest, 10, 100, "http://localhost");
+
+        Assert.assertEquals(result.getIndex().intValue(), 0);
+        Assert.assertEquals(result.getLastIndex().intValue(), 9);
+        Assert.assertEquals(result.getTotalElements().intValue(), 100);
+
+        Assert.assertNull(result.getFirstPage());
+        Assert.assertNull(result.getPreviousPage());
+        assertUrl(result.getNextPage(), 1, 10, "sort asc");
+        assertUrl(result.getLastPage(), 9, 10, "sort asc");
+    }
+
+    @Test
+    public void lastPage() throws Exception {
+        PageRequest pageRequest = new PageRequest(9, 10, "sort asc");
+
+        PositionView result = new PositionView(pageRequest, 10, 100, "http://localhost");
+
+        Assert.assertEquals(result.getIndex().intValue(), 9);
+        Assert.assertEquals(result.getLastIndex().intValue(), 9);
+        Assert.assertEquals(result.getTotalElements().intValue(), 100);
+
+        assertUrl(result.getFirstPage(), 0, 10, "sort asc");
+        assertUrl(result.getPreviousPage(), 8, 10, "sort asc");
+        Assert.assertNull(result.getNextPage());
+        Assert.assertNull(result.getLastPage());
+    }
+
+    @Test
+    public void middlePage() throws Exception {
+        PageRequest pageRequest = new PageRequest(5, 10, "sort asc");
+
+        PositionView result = new PositionView(pageRequest, 10, 100, "http://localhost");
+
+        Assert.assertEquals(result.getIndex().intValue(), 5);
+        Assert.assertEquals(result.getLastIndex().intValue(), 9);
+        Assert.assertEquals(result.getTotalElements().intValue(), 100);
+
+        assertUrl(result.getFirstPage(), 0, 10, "sort asc");
+        assertUrl(result.getPreviousPage(), 4, 10, "sort asc");
+        assertUrl(result.getNextPage(), 6, 10, "sort asc");
+        assertUrl(result.getLastPage(), 9, 10, "sort asc");
+    }
+
+    @Test
+    public void hashCodeEqualWhenDataEqual() throws Exception {
+        PositionView result1 = new PositionView(PAGE_REQUEST, 1, 1, "http://localhost");
+        PositionView result2 = new PositionView(PAGE_REQUEST, 1, 1, "http://localhost");
+
+        Assert.assertEquals(result1.hashCode(), result2.hashCode());
+    }
+
+    @Test
+    public void equalsNull() throws Exception {
+        PositionView result = new PositionView(PAGE_REQUEST, 1, 1, "http://localhost");
+
+        Assert.assertFalse(result.equals(null));
+    }
+
+    @Test
+    public void equalsDifferentClass() throws Exception {
+        PositionView result = new PositionView(PAGE_REQUEST, 1, 1, "http://localhost");
+
+        Assert.assertFalse(result.equals("string"));
+    }
+
+    @Test
+    public void equalsSelf() throws Exception {
+        PositionView result = new PositionView(PAGE_REQUEST, 1, 1, "http://localhost");
+
+        Assert.assertTrue(result.equals(result));
+    }
+
+    @Test
+    public void equalsDifferentData() throws Exception {
+        PositionView result1 = new PositionView(PAGE_REQUEST, 1, 1, "http://localhost1");
+        PositionView result2 = new PositionView(PAGE_REQUEST, 1, 1, "http://localhost2");
+
+        Assert.assertFalse(result1.equals(result2));
+    }
+
+    @Test
+    public void equalsSameData() throws Exception {
+        PositionView result1 = new PositionView(PAGE_REQUEST, 1, 1, "http://localhost");
+        PositionView result2 = new PositionView(PAGE_REQUEST, 1, 1, "http://localhost");
+
+        Assert.assertTrue(result1.equals(result2));
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        PositionView obj = new PositionView(PAGE_REQUEST, 10, 100, "http://localhost");
+
+        String result = obj.toString();
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.contains("index=1"));
+        Assert.assertTrue(result.contains("lastIndex=9"));
+        Assert.assertTrue(result.contains("totalElements=100"));
+        Assert.assertTrue(result.contains("firstPage=http://localhost?page=0&per_page=10&sort=sort asc"));
+        Assert.assertTrue(result.contains("previousPage=http://localhost?page=0&per_page=10&sort=sort asc"));
+        Assert.assertTrue(result.contains("nextPage=http://localhost?page=2&per_page=10&sort=sort asc"));
+        Assert.assertTrue(result.contains("lastPage=http://localhost?page=9&per_page=10&sort=sort asc"));
+    }
+
+    private void assertUrl(String url, int page, int perPage, String sort) {
+        UriComponents components = UriComponentsBuilder.fromUriString(url).build();
+
+        MultiValueMap<String, String> parameters = components.getQueryParams();
+
+        Assert.assertEquals(parameters.get("page").size(), 1);
+        Assert.assertEquals(parameters.get("per_page").size(), 1);
+        Assert.assertEquals(parameters.get("sort").size(), 1);
+
+        Assert.assertEquals(parameters.getFirst("page"), String.valueOf(page));
+        Assert.assertEquals(parameters.getFirst("per_page"), String.valueOf(perPage));
+        Assert.assertEquals(parameters.getFirst("sort"), sort);
+    }
+
+}


### PR DESCRIPTION
Add a representation for inclusion in paged responses that allows easier handling and presentation of paged data